### PR TITLE
fixing tests on ruby 2.0

### DIFF
--- a/lib/gemnasium/gitlab_service/client.rb
+++ b/lib/gemnasium/gitlab_service/client.rb
@@ -14,7 +14,7 @@ module Gemnasium
       # @params project [String] Identifier of the project
       #         files [Hash] files to upload; a file respond to :path, :sha and :content
 
-      def upload_files(files, project_slug:, branch_name:, commit_sha:)
+      def upload_files(files, project_slug, branch_name, commit_sha)
         payload = files.map do |f|
           { "path" => f.path, "sha" => f.sha, "content" => Base64.encode64(f.content) }
         end

--- a/lib/gemnasium/gitlab_service/pusher.rb
+++ b/lib/gemnasium/gitlab_service/pusher.rb
@@ -26,8 +26,8 @@ module Gemnasium
       def call
         if dependency_files.any?
           client.upload_files(
-            dependency_files, project_slug: project_slug,
-            branch_name: branch_name, commit_sha: commit_sha
+            dependency_files, project_slug,
+            branch_name, commit_sha
           )
         end
       end

--- a/spec/gemnasium/gitlab_service/client_spec.rb
+++ b/spec/gemnasium/gitlab_service/client_spec.rb
@@ -22,8 +22,8 @@ describe Gemnasium::GitlabService::Client do
 
     before do
       client.upload_files(
-        files, project_slug: 'project_slug',
-        branch_name: 'branch_name', commit_sha: 'commit_sha'
+        files, 'project_slug',
+        'branch_name', 'commit_sha'
       )
     end
 

--- a/spec/gemnasium/gitlab_service/pusher_spec.rb
+++ b/spec/gemnasium/gitlab_service/pusher_spec.rb
@@ -111,9 +111,9 @@ DEPENDENCIES
           file_class.new('depfiles/Gemfile', "68609d16b77711fd079668539a07a648fe837c84", gemfile_content),
           file_class.new('depfiles/Gemfile.lock', "c6d0eedc76b94d6412a9ab9741a10782116c1c47", lockfile_content),
         ],
-        project_slug: 'gemnasium-user/the-project',
-        branch_name: 'dev',
-        commit_sha: commit_sha,
+        'gemnasium-user/the-project',
+        'dev',
+        commit_sha,
       )
       pusher.call
     end


### PR DESCRIPTION
This hopefully fixes the tests on ruby 2.0, as it eliminates the kw-args introduced in client.rb

This would fix Issue #1 and also GitLab 7.9 on Ruby 2.0.

I'm a bit worried that this version of the Gem got released despite clearly breaking tests on TravisCI. As your gem is now a dependency of GitLab, you should feel a certain liablity for not breaking stuff. :)

I have no idea if this breaks external API (as I didn't look too deeply at the gem itself), so please review this carefully.

Thanks.
